### PR TITLE
Feature/issue-36-deprecate PseudoRealNumber.Provider関連非推奨APIにsinceパラメータを24.4.0として追加

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -1,5 +1,5 @@
 develop:
-PseudoRealNumber.Provider関連APIを@Deprecate.
+PseudoRealNumber.Provider関連APIを@Deprecate(since: 暫定 24.4.0　とする).
 
 24:
 24.3.0: rationalパッケージの削除. 内部の文字列リテラルの日本語を修正. リファクタリング(近似計算の内部構造). ドキュメントの更新.

--- a/src/matsu/num/approximation/ApproxTarget.java
+++ b/src/matsu/num/approximation/ApproxTarget.java
@@ -212,7 +212,7 @@ public abstract class ApproxTarget<T extends PseudoRealNumber<T>> {
      * @return 体の元に関するプロバイダ
      * @deprecated 将来の削除に向けて, 非推奨とする.
      */
-    @Deprecated
+    @Deprecated(since = "24.4.0")
     public PseudoRealNumber.Provider<T> elementProvider() {
         TypeProvider<T> out = typeProvider;
         if (Objects.nonNull(out)) {

--- a/src/matsu/num/approximation/Decimal128.java
+++ b/src/matsu/num/approximation/Decimal128.java
@@ -223,7 +223,7 @@ public final class Decimal128 extends PseudoRealNumber<Decimal128> {
      * @return プロバイダ
      * @deprecated 将来の削除に向けて, 非推奨とする.
      */
-    @Deprecated
+    @Deprecated(since = "24.4.0")
     public static PseudoRealNumber.Provider<Decimal128> elementProvider() {
         return TYPE_PROVIDER;
     }

--- a/src/matsu/num/approximation/DoubleLike.java
+++ b/src/matsu/num/approximation/DoubleLike.java
@@ -222,7 +222,7 @@ public final class DoubleLike extends PseudoRealNumber<DoubleLike> {
      * @return プロバイダ
      * @deprecated 将来の削除に向けて, 非推奨とする.
      */
-    @Deprecated
+    @Deprecated(since = "24.4.0")
     public static PseudoRealNumber.Provider<DoubleLike> elementProvider() {
         return TYPE_PROVIDER;
     }

--- a/src/matsu/num/approximation/PseudoRealNumber.java
+++ b/src/matsu/num/approximation/PseudoRealNumber.java
@@ -265,7 +265,7 @@ public abstract class PseudoRealNumber<T extends PseudoRealNumber<T>> implements
      * @return プロバイダ
      * @deprecated 将来の削除に向けて, 非推奨とする.
      */
-    @Deprecated
+    @Deprecated(since = "24.4.0")
     protected Provider<T> provider() {
         return null;
     }
@@ -495,7 +495,7 @@ public abstract class PseudoRealNumber<T extends PseudoRealNumber<T>> implements
      * @param <T> 体の元を表す型
      * @deprecated 将来の削除に向けて, 非推奨とする.
      */
-    @Deprecated
+    @Deprecated(since = "24.4.0")
     public static interface Provider<T extends PseudoRealNumber<T>> {
 
         /**
@@ -686,7 +686,7 @@ public abstract class PseudoRealNumber<T extends PseudoRealNumber<T>> implements
          * @throws NullPointerException 引数が nullの場合
          * @deprecated 将来の削除に向けて, 非推奨とする.
          */
-        @Deprecated
+        @Deprecated(since = "24.4.0")
         public static <T extends PseudoRealNumber<T>>
                 TypeProvider<T> from(Provider<T> provider) {
 

--- a/src/matsu/num/approximation/polynomial/Polynomial.java
+++ b/src/matsu/num/approximation/polynomial/Polynomial.java
@@ -86,6 +86,6 @@ public interface Polynomial<T extends PseudoRealNumber<T>> {
      *                 将来の削除に向けて, 非推奨とする. <br>
      *                 このインターフェースにおいて不要な要素であるので, 代替はない.
      */
-    @Deprecated
+    @Deprecated(since = "24.4.0")
     public abstract PseudoRealNumber.Provider<T> elementProvider();
 }


### PR DESCRIPTION
for issue #36 
PseudoRealNumber.Provider関連非推奨APIにsinceパラメータを24.4.0として追加